### PR TITLE
create normal and uv data where needed so bevy's renderer doesnt complain

### DIFF
--- a/src/loader.rs
+++ b/src/loader.rs
@@ -64,6 +64,8 @@ fn load_obj_from_bytes(bytes: &[u8], mesh: &mut Mesh) -> Result<(), ObjError> {
         1 => {
             let obj: obj::Obj<obj::Position, u32> = obj::Obj::new(raw)?;
             set_position_data(mesh, obj.vertices.iter().map(|v| v.position).collect());
+            set_normal_data(mesh, obj.vertices.iter().map(|_| [0., 0., 0.]).collect());
+            set_uv_data(mesh, obj.vertices.iter().map(|_| [0., 0., 0.]).collect());
             set_mesh_indices(mesh, obj);
         }
         2 => {
@@ -71,6 +73,7 @@ fn load_obj_from_bytes(bytes: &[u8], mesh: &mut Mesh) -> Result<(), ObjError> {
             let obj: obj::Obj<obj::Vertex, u32> = obj::Obj::new(raw)?;
             set_position_data(mesh, obj.vertices.iter().map(|v| v.position).collect());
             set_normal_data(mesh, obj.vertices.iter().map(|v| v.normal).collect());
+            set_uv_data(mesh, obj.vertices.iter().map(|_| [0., 0., 0.]).collect());
             set_mesh_indices(mesh, obj);
         }
         3 => {


### PR DESCRIPTION
I'm not sure if this is the right place to solve this problem (perhaps in an AssetCleanerPlugin), but this adds normal data (which is actually obviously broken, I could compute it from the face orientation..), and vertex uv data.

I have only tested this with a file missing UV data, so It is probably horribly broken when trying to inject normal data...

Is this something you would add to the crate? If so I will test it with normal data. Otherwise I will look at creating a  AssetCleanerPlugin.

Cheers 