### PR TITLE
load_obj_from_bytes -> pub

### DIFF
--- a/src/loader.rs
+++ b/src/loader.rs
@@ -84,7 +84,7 @@ impl From<MeshIndices> for Vec<u32> {
     }
 }
 
-fn load_obj_from_bytes(bytes: &[u8], mesh: &mut Mesh) -> Result<(), ObjError> {
+pub fn load_obj_from_bytes(bytes: &[u8], mesh: &mut Mesh) -> Result<(), ObjError> {
     let raw = obj::raw::parse_obj(bytes)?;
     let vertcount = raw.polygons.len() * 3;
 


### PR DESCRIPTION
This small change allows to load obj in scenarios where meshes are extracted prior bevy injection. For example for `MuJoCo` bodies the meshes can be described in xml as shapes or as links to obj files. Meshes are extracted on a stage where bevy `asset_server` is not yet available.