### PR TITLE
Move to tobj

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ bevy_math = "0.9"
 anyhow = "1.0"
 thiserror = "1.0"
 
-obj-rs = { version = "0.7", default-features = false }
+tobj = "3.2"
 
 [dev-dependencies]
 bevy = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ bevy_app = "0.10"
 bevy_asset = "0.10"
 bevy_render = "0.10"
 bevy_utils = "0.10"
-bevy_math = "0.10"
 
 anyhow = "1.0"
 thiserror = "1.0"

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -80,20 +80,20 @@ pub fn load_obj_from_bytes(mut bytes: &[u8]) -> Result<Mesh, ObjError> {
         indices.extend(model.mesh.indices);
     }
 
-    let mut bevy_mesh = Mesh::new(PrimitiveTopology::TriangleList);
+    let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
 
-    bevy_mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, vertex_position);
+    mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, vertex_position);
     if !vertex_texture.is_empty() {
-        bevy_mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, vertex_texture);
+        mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, vertex_texture);
     }
 
     if !vertex_normal.is_empty() {
-        bevy_mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, vertex_normal);
+        mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, vertex_normal);
     } else {
-        bevy_mesh.compute_flat_normals();
+        mesh.compute_flat_normals();
     }
 
-    bevy_mesh.set_indices(Some(Indices::U32(indices)));
+    mesh.set_indices(Some(Indices::U32(indices)));
 
-    Ok(bevy_mesh)
+    Ok(mesh)
 }

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -29,8 +29,6 @@ impl AssetLoader for ObjLoader {
 pub enum ObjError {
     #[error("Invalid OBJ file: {0}")]
     TobjError(#[from] tobj::LoadError),
-    #[error("Unexpected number of meshes, only 1 is supported")]
-    WrongMeshNumber,
 }
 
 async fn load_obj<'a, 'b>(
@@ -43,52 +41,59 @@ async fn load_obj<'a, 'b>(
 }
 
 fn load_mtl(_path: &std::path::Path) -> tobj::MTLLoadResult {
-    //TODO(luca) Implement mtl loading
     Err(tobj::LoadError::OpenFileFailed)
 }
 
 pub fn load_obj_from_bytes(mut bytes: &[u8]) -> Result<Mesh, ObjError> {
     let options = tobj::GPU_LOAD_OPTIONS;
-    match tobj::load_obj_buf(&mut bytes, &options, load_mtl) {
-        Ok(obj) => {
-            if obj.0.len() != 1 {
-                return Err(ObjError::WrongMeshNumber);
-            }
-            let mesh = &obj.0[0].mesh;
-
-            let vertex_position: Vec<[f32; 3]> = mesh
+    let obj = tobj::load_obj_buf(&mut bytes, &options, load_mtl)?;
+    let mut indices = Vec::new();
+    let mut vertex_position = Vec::new();
+    let mut vertex_normal = Vec::new();
+    let mut vertex_texture = Vec::new();
+    for model in obj.0 {
+        indices.reserve(model.mesh.indices.len());
+        vertex_position.reserve(model.mesh.positions.len() / 3);
+        vertex_normal.reserve(model.mesh.normals.len() / 3);
+        vertex_texture.reserve(model.mesh.texcoords.len() / 2);
+        vertex_position.extend(
+            model
+                .mesh
                 .positions
                 .chunks_exact(3)
-                .map(|v| [v[0], v[1], v[2]])
-                .collect();
-            let vertex_normal: Vec<[f32; 3]> = mesh
+                .map(|v| [v[0], v[1], v[2]]),
+        );
+        vertex_normal.extend(
+            model
+                .mesh
                 .normals
                 .chunks_exact(3)
-                .map(|n| [n[0], n[1], n[2]])
-                .collect();
-            let vertex_texture: Vec<[f32; 2]> = mesh
+                .map(|n| [n[0], n[1], n[2]]),
+        );
+        vertex_texture.extend(
+            model
+                .mesh
                 .texcoords
                 .chunks_exact(2)
-                .map(|t| [t[0], 1.0 - t[1]])
-                .collect();
-
-            let mut bevy_mesh = Mesh::new(PrimitiveTopology::TriangleList);
-
-            bevy_mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, vertex_position);
-            if !vertex_texture.is_empty() {
-                bevy_mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, vertex_texture);
-            }
-
-            if !vertex_normal.is_empty() {
-                bevy_mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, vertex_normal);
-            } else {
-                bevy_mesh.compute_flat_normals();
-            }
-
-            bevy_mesh.set_indices(Some(Indices::U32(mesh.indices.clone())));
-
-            Ok(bevy_mesh)
-        }
-        Err(err) => Err(ObjError::TobjError(err)),
+                .map(|t| [t[0], 1.0 - t[1]]),
+        );
+        indices.extend(model.mesh.indices);
     }
+
+    let mut bevy_mesh = Mesh::new(PrimitiveTopology::TriangleList);
+
+    bevy_mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, vertex_position);
+    if !vertex_texture.is_empty() {
+        bevy_mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, vertex_texture);
+    }
+
+    if !vertex_normal.is_empty() {
+        bevy_mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, vertex_normal);
+    } else {
+        bevy_mesh.compute_flat_normals();
+    }
+
+    bevy_mesh.set_indices(Some(Indices::U32(indices)));
+
+    Ok(bevy_mesh)
 }


### PR DESCRIPTION
Hi and thanks for the awesome crate!

I have been trying to use obj assets in bevy and ended up with a deal breaker issue caused by most of my assets using four sided polygons instead of triangles, which would have required me to open each of them into the editor of choice, triangulate them, then reexport them since this crate just [fails](https://github.com/AmionSky/bevy_obj/blob/0ef16687e25e72541aa8a5e3c6e9d8301e74d945/src/loader.rs#L34) for non triangulated meshes.

While looking at possible solutions for triangulations I noticed that a different obj upstream crate, specifically [tobj](https://github.com/Twinklebear/tobj) supports common preprocessing such as triangulating meshes. I also did a quick check on crates.io to sort obj crates by popularity / last updates and `tobj` ranks [pretty high](https://crates.io/search?q=wavefront%20obj&sort=downloads), second to only `wavefront_obj` that hasn't seen much activity in the last few years.

This PR is almost an RFC, it targets bevy 0.9 since that's what I needed for my use case so it can't be merged as-is but it should be trivially portable to bevy 0.10 and I'm happy to do that if you are open to this direction, otherwise I'll just keep my own fork for the time being.
All my assets render fine, the bundled example also still works so regressions, if present, are not too obvious to me.

The main regression will probably be from a memory footprint point of view, the default preprocessing for [GPU_LOAD_OPTIONS](https://docs.rs/tobj/latest/tobj/constant.GPU_LOAD_OPTIONS.html) may duplicate normals / texture coordinates to use a single index ([this](https://docs.rs/tobj/latest/tobj/struct.LoadOptions.html#structfield.single_index) option is set to `true`). This helped make the code a bit simpler and remove a few artifacts but it can probably be reverted if needed.
I also don't know if general loading / parsing performance will be better or worse.

Still left TODO, but not in the scope of this PR, is the implementation of #8, I left a stub for loading MTLs and I'll probably address that next since I also need that for my usecase.

What do you think?