### PR TITLE
Allow files to be fetched from multiple sources

### DIFF
--- a/src/loader/scene.rs
+++ b/src/loader/scene.rs
@@ -53,8 +53,8 @@ async fn load_obj_data<'a, 'b>(
         // But we are unable to call ctx.finish() and feed the result back. (which is no new asset)
         // Is this allowed?
         let mut ctx = load_context.begin_labeled_asset();
-        let path = ctx.path().with_file_name(p);
-        let asset_path = AssetPath::from_path(&path);
+        let path = PathBuf::from(ctx.asset_path().to_string()).with_file_name(p);
+        let asset_path = AssetPath::from(path.to_string_lossy().into_owned());
         ctx.read_asset_bytes(&asset_path)
             .await
             .map_or(Err(tobj::LoadError::OpenFileFailed), |bytes| {
@@ -69,8 +69,9 @@ fn load_mat_texture(
     load_context: &mut LoadContext,
 ) -> Option<Handle<Image>> {
     if let Some(texture) = texture {
-        let path = load_context.path().with_file_name(texture);
-        Some(load_context.load(path))
+        let path = PathBuf::from(load_context.asset_path().to_string()).with_file_name(texture);
+        let asset_path = AssetPath::from(path.to_string_lossy().into_owned());
+        Some(load_context.load(&asset_path))
     } else {
         None
     }


### PR DESCRIPTION
Bevy asset V2 allows multiple asset sources in the form of (for example) `source://file.ext`.
When fetching mtl files however, this plugin uses the `path` and not the `asset_path`, which means that the source would be silently dropped, for example:

```
asset_server.load("source://file.obj");
// File.obj contains a reference to `file.mtl`
// Mtl lookup will try to fetch `file.mtl` and fail.
```

This PR makes sure that we keep the asset source, so the above would look for `source://file.mtl`.
Note that the code works but is a bit ugly, I can't quite find a cleaner way to do it since it seems `AssetPath` does not offer a `with_file_name` API. There is also the question of whether we want to have lossy conversion or return errors on non utf-8 paths.
I tried (and failed) to just do a `let source = ctx.source();` call and a `path.with_source(source);` but I couldn't get it to compile, not very well versed in `async` Rust.