### PR TITLE
add uppercase file extension

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ use bevy::app::{App, Plugin};
 use bevy::asset::AssetApp;
 use serde::{Deserialize, Serialize};
 
-const EXTENSIONS: &[&str; 1] = &["obj"];
+const EXTENSIONS: &[&str; 2] = &["obj", "OBJ"];
 
 /// Adds support for OBJ asset loading
 #[derive(Default)]


### PR DESCRIPTION
Bevy 0.16 had became case-sensitive for asset file extensions https://github.com/bevyengine/bevy/pull/17065  
So add uppercase `OBJ` extension to keep the original behavior of bevy_obj plugin